### PR TITLE
Fix window_open not being properly called in app services

### DIFF
--- a/apps/conversation/service.gd
+++ b/apps/conversation/service.gd
@@ -4,4 +4,4 @@ const CHAT_PANEL = preload("chat_panel.tscn")
 
 func _icon_activated() -> void:
 	var window = CHAT_PANEL.instantiate()
-	Desktop.current.window_open(window)
+	window_open(window)

--- a/apps/files/service.gd
+++ b/apps/files/service.gd
@@ -7,6 +7,6 @@ var window: AppWindow
 func _icon_activated() -> void:
 	if not is_instance_valid(window):
 		window = WINDOW.instantiate()
-		Desktop.current.window_open(window)
+		window_open(window)
 	else:
 		Desktop.current.window_bring_to_front(window)

--- a/apps/image_viewer/service.gd
+++ b/apps/image_viewer/service.gd
@@ -25,7 +25,7 @@ func _can_open_document(document: Document) -> bool:
 func _open_document(document: Document) -> void:
 	var window = VIEWER.instantiate()
 	window.document = document
-	Desktop.current.window_open(window)
+	window_open(window)
 
 enum {
 	NOTIFICATION_LAUNCH_DOCUMENT,
@@ -36,4 +36,4 @@ func _app_notification(what: int, data: Variant) -> void:
 		NOTIFICATION_LAUNCH_DOCUMENT:
 			var window = VIEWER.instantiate()
 			window.document = data as Document
-			Desktop.current.window_open(window)
+			window_open(window)

--- a/apps/notepad/service.gd
+++ b/apps/notepad/service.gd
@@ -8,7 +8,7 @@ const NOTEPAD = preload("notepad.tscn")
 
 func _icon_activated() -> void:
 	var window = NOTEPAD.instantiate()
-	Desktop.current.window_open(window)
+	window_open(window)
 
 func _can_open_document(document: Document) -> bool:
 	return document.get_file_name().get_extension() in SUPPORTED_EXTS
@@ -16,4 +16,4 @@ func _can_open_document(document: Document) -> bool:
 func _open_document(document: Document) -> void:
 	var window = NOTEPAD.instantiate()
 	window.document = document
-	Desktop.current.window_open(window)
+	window_open(window)

--- a/framework/shells/default/shell.tscn
+++ b/framework/shells/default/shell.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://bv1f6xupdnd3w" path="res://framework/shells/default/shell.gd" id="1_qlls7"]
 [ext_resource type="Script" uid="uid://bwttgystohi7o" path="res://framework/shells/default/app_item_list.gd" id="2_nwivk"]
 [ext_resource type="Texture2D" uid="uid://mh48osisb557" path="res://themes/cyberfire/cyberfire_icons.png" id="2_pdc4m"]
-[ext_resource type="PackedScene" path="res://framework/shells/default/send_recv_icon.tscn" id="2_ww856"]
+[ext_resource type="PackedScene" uid="uid://b6piwmude7tao" path="res://framework/shells/default/send_recv_icon.tscn" id="2_ww856"]
 [ext_resource type="Script" uid="uid://bsk5525ny6cuu" path="res://framework/shells/default/search_line_edit.gd" id="3_82wmq"]
 [ext_resource type="Script" uid="uid://dj3dbs6vq5jwh" path="res://framework/shells/default/file_item_list.gd" id="4_hoiib"]
 [ext_resource type="Script" uid="uid://5jt0ny5rpjmy" path="res://framework/shells/default/settings_item_list.gd" id="5_6w2ko"]


### PR DESCRIPTION
`Desktop.window_open` was changed to require apps to call through `AppService.window_open` instead, this PR fixes existing apps which weren't correctly updated.